### PR TITLE
Set max_new_tokens=1024

### DIFF
--- a/florence2.py
+++ b/florence2.py
@@ -251,7 +251,7 @@ class Florence2(Model):
         image: Image.Image,
         task: str,
         text_input: Optional[str] = None,
-        max_new_tokens: int = 4096,
+        max_new_tokens: int = 1024,
         num_beams: int = 3,
     ):
         """Generate and parse a response from the model.


### PR DESCRIPTION
It turns out that the model can't support 4096 and will throw a cuda error when PyTorch is trying to access an element in a tensor using an index that's out of bounds 